### PR TITLE
Fixed dead config property continueAfterMotion & added 'keepMotionImages' config property

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,5 +47,8 @@ const motionDetector = new MotionDetectionModule({
   
   captureVideoOnMotion: false, // Defaults to false
                                // Flag to control video capture on motion detection
+  
+  keepMotionImages: true,      // Defaults to true
+                               // Flag to control if motion detection should keep images after detection
 });
 ```

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ class MotionDetectionModule extends EventEmitter {
       captureDirectory: null, // Directory to store tmp photos and video captures
       continueAfterMotion: false, // Flag to control if motion detection will continue after detection
       captureVideoOnMotion: false, // Flag to control video capture on motion detection
+      keepMotionImages: true, // Flag to control if motion detection should keep images after detection
     }, options);
 
     this.continueToCapture = true; // Flag to control internal state of photo capture
@@ -28,7 +29,7 @@ class MotionDetectionModule extends EventEmitter {
     const imageCaptureChild = fork(path.resolve(__dirname, 'lib', 'ImageCapture.js'), [ path.resolve(self.config.captureDirectory, 'images', '%d.jpg') ]);
     const videoCaptureChild = fork(path.resolve(__dirname, 'lib', 'VideoCapture.js'), [ path.resolve(self.config.captureDirectory, 'videos', 'video.h264') ]);
     const videoRenameChild = fork(path.resolve(__dirname, 'lib', 'VideoRename.js'), [ path.resolve(self.config.captureDirectory, 'videos') ]);
-    const imageCompare = new ImageCompare(path.resolve(self.config.captureDirectory, 'images'));
+    const imageCompare = new ImageCompare(path.resolve(self.config.captureDirectory, 'images'), self.config.keepMotionImages);
 
     imageCaptureChild.on('message', (message) => {
       if (message.result === 'failure') {

--- a/lib/ImageCompare.js
+++ b/lib/ImageCompare.js
@@ -6,9 +6,10 @@ const Jimp = require('jimp');
 const EventEmitter = require('events');
 
 class ImageCompare extends EventEmitter {
-  constructor(capturesDir) {
+  constructor(capturesDir, keepMotionImages) {
     super();
     this.capturesDir = capturesDir;
+    this.keepMotionImages = keepMotionImages;
     this.controlFileName = null;
     this.compareFileName = null;
     this.COMPARE_THRESHOLD = 0.1;
@@ -48,7 +49,7 @@ class ImageCompare extends EventEmitter {
                       self.emit('error', error);
                     }
 
-                    if (motionDetected) {
+                    if (motionDetected && self.keepMotionImages) {
                       self.controlFileName = null;
                       self.compareFileName = null;
                     }


### PR DESCRIPTION
Hi!

My goal with this PR is:
- Fixed dead config property `continueAfterMotion` because I want to keep image detecting without video capturing. 
- Added `keepMotionImages` property (default: true). It is suitable when I want to use this package ONLY as "motion detector" without keeping motioned images (especially on RPi SD card or `tmpfs`).

_I kept your code-style even I know that it's not perfect. There's refactoring necessary in this module. :)_

Best regards, 
Buri. :)